### PR TITLE
 No hints for feedly.com Fix #440 

### DIFF
--- a/extension/lib/commands.coffee
+++ b/extension/lib/commands.coffee
@@ -29,7 +29,7 @@ _          = require('./l10n')
 , setPref
 , isPrefSet } = require('./prefs')
 
-{ isProperLink, isTextInputElement, isContentEditable } = utils
+{ isProperLink, isTextInputElement, isContentEditable, isDataApp } = utils
 
 { classes: Cc, interfaces: Ci, utils: Cu } = Components
 
@@ -261,7 +261,7 @@ combine = (hrefs, marker) ->
     else
       hrefs[href] = marker
   return marker
-  
+
 # Follow links, focus text inputs and click buttons with hint markers.
 command_follow = (vim, event, count, newTab, inBackground) ->
   hrefs = {}
@@ -288,7 +288,9 @@ command_follow = (vim, event, count, newTab, inBackground) ->
            element.hasAttribute('oncommand') or
            element.getAttribute('role') in ['link', 'button'] or
            # Twitter special-case.
-           element.classList.contains('js-new-tweets-bar')
+           element.classList.contains('js-new-tweets-bar') or
+           # Feedly special-case.
+           isDataApp(element)
         type = 'clickable'
         semantic = false
       # Putting markers on `<label>` elements is generally redundant, because
@@ -357,6 +359,7 @@ command_marker_yank = (vim) ->
   filter = (element, getElementShape) ->
     type = switch
       when isProperLink(element)       then 'link'
+      when isDataApp(element)          then 'link'
       when isTextInputElement(element) then 'textInput'
       when isContentEditable(element)  then 'contenteditable'
     return unless type

--- a/extension/lib/utils.coffee
+++ b/extension/lib/utils.coffee
@@ -120,6 +120,12 @@ isGoogleEditable = (element) ->
   return element.getAttribute?('g_editable') == 'true' or
          element.ownerDocument.body?.getAttribute('g_editable') == 'true'
 
+isDataApp = (element) ->
+  # `data-app-action and data-uri` are a non-standard attributes commonly used by Feedly.
+  return element.hasAttribute('data-app-action') or
+         element.hasAttribute('data-uri') or
+         element.hasAttribute('data-page-action')
+
 isActivatable = (element) ->
   return element instanceof HTMLAnchorElement or
          element instanceof HTMLButtonElement or
@@ -416,6 +422,7 @@ exports.blurActiveElement         = blurActiveElement
 exports.isProperLink              = isProperLink
 exports.isTextInputElement        = isTextInputElement
 exports.isContentEditable         = isContentEditable
+exports.isDataApp                 = isDataApp
 exports.isActivatable             = isActivatable
 exports.isAdjustable              = isAdjustable
 exports.area                      = area


### PR DESCRIPTION
Fix for feedly.com hints generation.
Added new function to check for this element attributes:
```
data-app-action
data-uri
data-page-action
```